### PR TITLE
expose SPECS_SIZE variable to chart

### DIFF
--- a/templates/configmap.yml
+++ b/templates/configmap.yml
@@ -11,6 +11,7 @@ data:
   VSPHERE_USER: {{ .Values.vsphere.user | quote }}
   VSPHERE_HOST: {{ .Values.vsphere.host | quote }}
   VSPHERE_IGNORE_SSL: {{ .Values.vsphere.ignoressl | quote }}
+  VSPHERE_SPECS_SIZE: {{ .Values.vsphere.specsSize | quote }}
   VSPHERE_COLLECT_HOSTS: {{ .Values.vsphere.collectors.hosts | quote }}
   VSPHERE_COLLECT_DATASTORES: {{ default "True" .Values.vsphere.collectors.datastores | quote }}
   VSPHERE_COLLECT_VMS: {{ .Values.vsphere.collectors.vms | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -7,6 +7,7 @@ vsphere:
   password: na
   host: vcenter
   ignoressl: true
+  specsSize: 5000
   collectors:
     hosts: true
     datastores: true


### PR DESCRIPTION
The exporter has a config var that is not in the chart: SPECS_SIZE. This adds the var