### PR TITLE
feat: use secret to provide vCenter password

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `podSecurityContext`                      | Security Context for the Pod                  | `{}`                                                    |
 | `vsphere.user`                            | User for vcenter login                        | `user`                                                  |
 | `vsphere.password`                        | Password for vcenter login                    | `na`                                                    |
+| `vsphere.passwordSecret`                  | Provide password for vCenter login w/ secret  |                                                         |
 | `vsphere.host`                            | Hostname or IP for vcenter login              | `vcenter`                                               |
 | `vsphere.ignoressl`                       | User for vcenter                              | `user`                                                  |
 | `vsphere.collectors.hosts`                | Collect host metrics                          | `true`                                                  |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `podSecurityContext`                      | Security Context for the Pod                  | `{}`                                                    |
 | `vsphere.user`                            | User for vcenter login                        | `user`                                                  |
 | `vsphere.password`                        | Password for vcenter login                    | `na`                                                    |
-| `vsphere.passwordSecret`                  | Provide password for vCenter login w/ secret  |                                                         |
+| `vsphere.existingSecret`                  | Provide password for vCenter login w/ secret  |                                                         |
 | `vsphere.host`                            | Hostname or IP for vcenter login              | `vcenter`                                               |
 | `vsphere.ignoressl`                       | User for vcenter                              | `user`                                                  |
 | `vsphere.collectors.hosts`                | Collect host metrics                          | `true`                                                  |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
             - configMapRef:
                 name: {{ template "vmware-exporter.fullname" . }}-config
             - secretRef:
-                name: {{ template "vmware-exporter.fullname" . }}-secret
+                name: {{ if not .Values.vsphere.existingSecret }}{{ template "vmware-exporter.fullname" . }}-secret{{ else }}{{ .Values.vsphere.existingSecret }}{{ end }}
           livenessProbe:
 {{ toYaml .Values.livenessProbe | indent 12 }}
           readinessProbe:

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.vsphere.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,4 +14,5 @@ data:
 {{- range $section := .Values.vsphere.sections }}
 {{- $key := $section.name }}
   VSPHERE_{{ $key }}_PASSWORD: {{ $section.password | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -4,6 +4,7 @@ replicaCount: 1
 vsphere:
   user: user
   password: na
+  existingSecret: {}
   host: vcenter
   ignoressl: true
   fetchCustomAttributes: true


### PR DESCRIPTION
we store our Helm chart configs in git, therefore currently we cannot use the chart as it requires to provide the password through values.yaml