### PR TITLE
update service template to allow addition of labels from .Values.service.labels

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -8,6 +8,9 @@ metadata:
     chart: {{ template "vmware-exporter.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- range $key, $value := .Values.service.labels }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
 {{- with .Values.service.annotations }} 
   annotations: 
 {{ toYaml . | indent 4 }} 


### PR DESCRIPTION
the vlaues.yaml file and the README.md file in this repository suggest that supplying the key:

```
service:
  ...
  labels:
    foo: bar
    boo: far
```

would render the labels into the service object at chart application time but this however is not the case. this PR will provide that functionality.

test this PR by pulling the repo, enabling the service in values.yaml and setting the labels map similar to above.